### PR TITLE
fix: allow zero-priced menu items

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,8 @@
       const revenueToday = orders.filter(o => new Date(o.createdAt).toDateString() === new Date().toDateString()).reduce((s,o)=>s+o.total,0);
 
       function addItem(newItem) {
-        if (!newItem.name || !newItem.price) return;
+        // Permit price of 0 but guard against empty or non-numeric values
+        if (!newItem.name || newItem.price === "" || isNaN(Number(newItem.price))) return;
         const item = { id: uuid(), name: newItem.name, desc: newItem.desc||"", price: Number(newItem.price), category: newItem.category||"Other", available: true, modifiers: [] };
         setMenu([item, ...menu]);
       }


### PR DESCRIPTION
## Summary
- prevent validation from rejecting free menu items

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df160c05c832aa7d73f9604310b8c