### PR TITLE
fix: allow zero-priced menu items

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,8 +529,10 @@
       const revenueToday = orders.filter(o => new Date(o.createdAt).toDateString() === new Date().toDateString()).reduce((s,o)=>s+o.total,0);
 
       function addItem(newItem) {
-        if (!newItem.name || !newItem.price) return;
-        const item = { id: uuid(), name: newItem.name, desc: newItem.desc||"", price: Number(newItem.price), category: newItem.category||"Other", available: true, modifiers: [] };
+        const price = Number(newItem.price);
+        // Permit price of 0 but guard against empty, non-numeric, or negative values
+        if (!newItem.name || newItem.price === "" || isNaN(price) || price < 0) return;
+        const item = { id: uuid(), name: newItem.name, desc: newItem.desc||"", price, category: newItem.category||"Other", available: true, modifiers: [] };
         setMenu([item, ...menu]);
       }
       function toggleAvailability(id) { setMenu(menu.map(m => m.id===id ? {...m, available: !m.available} : m)); }


### PR DESCRIPTION
## Summary
- prevent validation from rejecting free menu items
- reject negative prices by validating numeric input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df160c05c832aa7d73f9604310b8c